### PR TITLE
Script System Extensions for writing async methods

### DIFF
--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -28,6 +28,7 @@ Welcome to the Stride Community Toolkit Manual. This comprehensive guide is desi
 - [Game Extensions](game-extensions/index.md): Extensions ranging from performance monitoring to material creation and entity manipulation.
 - [Model Extensions](model-extensions/index.md)
 - [Script Extensions](script-extensions/index.md): Additional features and tools for game development.
+- [Script System Extensions](script-system-extensions/index.md): Provides utilities for writing async methods.
 - Rendering: A guide on rendering techniques.
   - [MeshBuilder](rendering/mesh-builder.md): A utility class allowing dynamic creation of meshes at runtime.
   - [TextureCanvas](rendering/texture-canvas.md): a utility class allowing dynamic creation of textures at runtime.

--- a/docs/manual/script-system-extensions/index.md
+++ b/docs/manual/script-system-extensions/index.md
@@ -1,0 +1,8 @@
+# ScriptSystemExtensions.cs
+
+![Done](https://img.shields.io/badge/status-done-green)
+
+- [`DelayWarped()`](xref:Stride.CommunityToolkit.Engine.ScriptSystemExtensions.DelayWarped(Stride.Engine.Processors.ScriptSystem,System.Single)) - Waits for a specified amount of time while taking into account the Update Time factor
+- [`Delay()`](xref:Stride.CommunityToolkit.Engine.ScriptSystemExtensions.Delay(Stride.Engine.Processors.ScriptSystem,System.Single)) - Waits for a specified amount of time without considering the Update Time factor
+- [`ExecuteInWarpedTime()`](xref:Stride.CommunityToolkit.Engine.ScriptSystemExtensions.ExecuteInWarpedTime(Stride.Engine.Processors.ScriptSystem,System.Single,System.Action{System.Single})) - Continuously executes an action every frame during a specified amount of time while taking into account the Update Time factor
+- [`ExecuteInTime()`](xref:Stride.CommunityToolkit.Engine.ScriptSystemExtensions.ExecuteInTime(Stride.Engine.Processors.ScriptSystem,System.Single,System.Action{System.Single})) - Continuously executes an action every frame during a specified amount of time without considering the Update Time factor

--- a/docs/manual/toc.yml
+++ b/docs/manual/toc.yml
@@ -53,6 +53,8 @@
   href: model-extensions/index.md
 - name: Script Extensions
   href: script-extensions/index.md
+- name: Script System Extensions
+  href: script-system-extensions/index.md
 - name: Rendering
   items:
   - name: MeshBuilder

--- a/src/Stride.CommunityToolkit/Engine/ScriptSystemExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/ScriptSystemExtensions.cs
@@ -1,0 +1,67 @@
+using Stride.Engine.Processors;
+
+namespace Stride.CommunityToolkit.Engine;
+
+public static class ScriptSystemExtensions
+{
+    /// <summary>
+    /// Waits for a specified amount of time while taking into account the Update Time factor.
+    /// </summary>
+    /// <param name="script">The script system.</param>
+    /// <param name="seconds">The amount of time to be delayed.</param>
+    /// <returns>A <see cref="Task"/> that represents the time delay.</returns>
+    public static async Task DelayWarped(this ScriptSystem script, float seconds)
+    {
+        float t = 0f;
+        while (script.Game.IsRunning && t < seconds)
+        {
+            t += (float)script.Game.UpdateTime.WarpElapsed.TotalSeconds;
+            await script.NextFrame();
+        }
+    }
+
+    /// <summary>
+    /// Waits for a specified amount of time.
+    /// </summary>
+    /// <param name="script">The script system.</param>
+    /// <param name="seconds">The amount of time to be delayed.</param>
+    /// <returns>A <see cref="Task"/> that represents the time delay.</returns>
+    public static async Task Delay(this ScriptSystem script, float seconds) =>
+        await Task.Delay((int)(seconds * 1000f));
+
+    /// <summary>
+    /// Continuously executes an action every frame during a specified amount of time while taking into account the Update Time factor.
+    /// </summary>
+    /// <param name="script">The script system.</param>
+    /// <param name="seconds">The duration in seconds.</param>
+    /// <param name="action">The action that will be executed every frame.</param>
+    /// <returns>A <see cref="Task"/> that represents the execution.</returns>
+    public static async Task ExecuteInWarpedTime(this ScriptSystem script, float seconds, Action<float> action)
+    {
+        float t = 0f;
+        while (script.Game.IsRunning && t < seconds)
+        {
+            t += (float)script.Game.UpdateTime.WarpElapsed.TotalSeconds;
+            action?.Invoke(t);
+            await script.NextFrame();
+        }
+    }
+
+    /// <summary>
+    /// Continuously executes an action every frame during a specified amount of time.
+    /// </summary>
+    /// <param name="script">The script system.</param>
+    /// <param name="seconds">The duration in seconds.</param>
+    /// <param name="action">The action that will be executed every frame.</param>
+    /// <returns>A <see cref="Task"/> that represents the execution.</returns>
+    public static async Task ExecuteInTime(this ScriptSystem script, float seconds, Action<float> action)
+    {
+        float t = 0f;
+        while (script.Game.IsRunning && t < seconds)
+        {
+            t += (float)script.Game.UpdateTime.Elapsed.TotalSeconds;
+            action?.Invoke(t);
+            await script.NextFrame();
+        }
+    }
+}


### PR DESCRIPTION
I've created script system extensions for writing async methods:

### Delay
It makes creating a delay task more consistent with the rest of the extensions and uses seconds instead of milliseconds.

### DelayWarped
Works similar to `Delay`, except that it considers the current Update Time factor. It will also adjust itself if the factor changes during the delay.

### ExecuteInTime
Executes an action every frame for a specified amount of time. It's useful for things like animating. Example:
```cs
//Moves the entity by one meter up in the span of 2 seconds
await Script.ExecuteInTime(2f, t =>
{
    Entity.Transform.Position = Vector3.UnitY * Math.Clamp(t / 2f, 0f, 1f),
});
```

### ExecuteInTime
Simular to `ExecuteInTime`, except that it considers the current Update Time factor.

---

The code includes documentation comments and I've included a script-system-extensions page in the manual