### PR TITLE
Fix getcamera

### DIFF
--- a/src/Stride.CommunityToolkit/Engine/EntityExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/EntityExtensions.cs
@@ -85,6 +85,32 @@ public static class EntityExtensions
     }
 
     /// <summary>
+    /// Recursively searches for the first component of the specified type in the entity's children.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    public static T? GetComponentInChildren<T>(this Entity entity)
+    {
+        var result = entity.OfType<T>().FirstOrDefault();
+
+        if (result is null)
+        {
+            var children = entity.GetChildren();
+            foreach(var child in children)
+            {
+                result = child.GetComponentInChildren<T>();
+                if (result != null)
+                {
+                    return result;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Retrieves all components of the specified type from the entity.
     /// </summary>
     /// <typeparam name="T">The type of components to retrieve.</typeparam>
@@ -114,6 +140,31 @@ public static class EntityExtensions
     public static Entity? FindEntity(this Entity entity, string name)
     {
         return entity.Scene.Entities.FirstOrDefault(w => w.Name == name);
+    }
+
+    /// <summary>
+    /// Searches for an entity by name within the top-level entities of the current scene.
+    /// </summary>
+    /// <param name="entity">The reference entity used to access the scene.</param>
+    /// <param name="name">The name of the entity to find.</param>
+    /// <returns>The first entity matching the specified name, or null if no match is found. This search does not include child entities.</returns>
+    public static Entity? FindEntityRecursive(this Entity entity, string name)
+    {
+        var entities = entity.Scene.Entities;
+        for (int i = 0; i < entities.Count; i++)
+        {
+            if (entities[i].Name == name)
+            {
+                return entities[i];
+            }
+            var child = entities[i].FindChild(name);
+            if(child != null && child.Name == name)
+            {
+                return child;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Stride.CommunityToolkit/Engine/EntityExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/EntityExtensions.cs
@@ -145,19 +145,19 @@ public static class EntityExtensions
     /// <summary>
     /// Searches for an entity by name within the top-level entities of the current scene.
     /// </summary>
-    /// <param name="entity">The reference entity used to access the scene.</param>
+    /// <param name="parent">The reference entity used to access the scene.</param>
     /// <param name="name">The name of the entity to find.</param>
     /// <returns>The first entity matching the specified name, or null if no match is found. This search does not include child entities.</returns>
-    public static Entity? FindEntityRecursive(this Entity entity, string name)
+    public static Entity? FindEntityRecursive(this Entity parent, string name)
     {
-        var entities = entity.Scene.Entities;
-        for (int i = 0; i < entities.Count; i++)
+        var entities = parent.Scene.Entities;
+        foreach(var entity in entities)
         {
-            if (entities[i].Name == name)
+            if (entity.Name == name)
             {
-                return entities[i];
+                return entity;
             }
-            var child = entities[i].FindChild(name);
+            var child = entity.FindChild(name);
             if(child != null && child.Name == name)
             {
                 return child;

--- a/src/Stride.CommunityToolkit/Engine/SceneExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/SceneExtensions.cs
@@ -1,0 +1,47 @@
+using Stride.Engine;
+
+namespace Stride.CommunityToolkit.Engine;
+public static class SceneExtensions
+{
+
+	/// <summary>
+	/// Gets the first camera in the scene.
+	/// </summary>
+	/// <param name="scene"></param>
+	/// <returns></returns>
+	public static CameraComponent? GetCamera(this Scene scene)
+	{
+		var entities =  scene.Entities;
+        CameraComponent? camera = null;
+        foreach (var entity in entities)
+        {
+            camera = entity.GetComponentInChildren<CameraComponent>();
+            if (camera != null)
+            {
+				break;
+			}
+        }
+        return camera;
+	}
+
+	/// <summary>
+	/// Gets the first camera in the scene with the specified <see cref="Entity"/> name.
+	/// </summary>
+	/// <param name="scene"></param>
+	/// <param name="name"></param>
+	/// <returns></returns>
+	public static CameraComponent? GetCamera(this Scene scene, string name)
+	{
+		var entities = scene.Entities;
+		CameraComponent? camera = null;
+		foreach (var entity in entities)
+		{
+			camera = entity.GetComponentInChildren<CameraComponent>();
+			if (camera != null && camera.Entity.Name == name)
+			{
+				break;
+			}
+		}
+		return camera;
+	}
+}

--- a/src/Stride.CommunityToolkit/Engine/ScriptComponentExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/ScriptComponentExtensions.cs
@@ -23,7 +23,31 @@ public static class ScriptComponentExtensions
     /// </remarks>
     /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
     /// <returns>The <see cref="CameraComponent"/> named "Main", if found; otherwise, null.</returns>
+    [Obsolete("Use GetGCCamera instead")]
     public static CameraComponent? GetCamera(this ScriptComponent scriptComponent)
+    {
+        var cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
+
+        foreach (var sceneCamera in cameraCollection)
+        {
+            if (sceneCamera.Name == "Main")
+            {
+                return sceneCamera.Camera;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves the camera named "Main" from the <see cref="GraphicsCompositor"/>. Note that the camera might not be available during the first 2-3 frames.
+    /// </summary>
+    /// <remarks>
+    /// Ensure that the GraphicsCompositor is initialized with cameras; otherwise, this method will fail.
+    /// </remarks>
+    /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
+    /// <returns>The <see cref="CameraComponent"/> named "Main", if found; otherwise, null.</returns>
+    public static CameraComponent? GetGCCamera(this ScriptComponent scriptComponent)
     {
         var cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
 
@@ -47,7 +71,32 @@ public static class ScriptComponentExtensions
     /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
     /// <param name="cameraName">The name of the camera to retrieve.</param>
     /// <returns>The <see cref="CameraComponent"/> with the given name, if found; otherwise, null.</returns>
+    [Obsolete("Use GetGCCamera instead")]
     public static CameraComponent? GetCamera(this ScriptComponent scriptComponent, string cameraName)
+    {
+        var cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
+
+        foreach (var sceneCamera in cameraCollection)
+        {
+            if (sceneCamera.Name == cameraName)
+            {
+                return sceneCamera.Camera;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves the camera from the <see cref="GraphicsCompositor"/> with the specified name. Note that the camera might not be available during the first 2-3 frames.
+    /// </summary>
+    /// <remarks>
+    /// Ensure that the GraphicsCompositor is initialized with cameras; otherwise, this method will fail.
+    /// </remarks>
+    /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
+    /// <param name="cameraName">The name of the camera to retrieve.</param>
+    /// <returns>The <see cref="CameraComponent"/> with the given name, if found; otherwise, null.</returns>
+    public static CameraComponent? GetGCCamera(this ScriptComponent scriptComponent, string cameraName)
     {
         var cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
 
@@ -70,7 +119,23 @@ public static class ScriptComponentExtensions
     /// </remarks>
     /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
     /// <returns>The <see cref="CameraComponent"/> with the given name, if found; otherwise, null.</returns>
+    [Obsolete("Use GetFirstGCCamera instead")]
     public static CameraComponent GetFirstCamera(this ScriptComponent scriptComponent)
+    {
+        SceneCameraSlotCollection cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
+
+        return cameraCollection[0].Camera;
+    }
+
+    /// <summary>
+    /// Gets the first camera from the <see cref="GraphicsCompositor"/>. Note that the camera might not be available during the first 2-3 frames.
+    /// </summary>
+    /// <remarks>
+    /// Ensure that the GraphicsCompositor is initialized with cameras; otherwise, this method will fail.
+    /// </remarks>
+    /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
+    /// <returns>The <see cref="CameraComponent"/> with the given name, if found; otherwise, null.</returns>
+    public static CameraComponent GetFirstGCCamera(this ScriptComponent scriptComponent)
     {
         SceneCameraSlotCollection cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
 

--- a/src/Stride.CommunityToolkit/Engine/ScriptComponentExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/ScriptComponentExtensions.cs
@@ -23,7 +23,7 @@ public static class ScriptComponentExtensions
     /// </remarks>
     /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
     /// <returns>The <see cref="CameraComponent"/> named "Main", if found; otherwise, null.</returns>
-    [Obsolete("Use GetGCCamera instead")]
+    [Obsolete("Use GetGCCamera instead or use Scene.GetCamera")]
     public static CameraComponent? GetCamera(this ScriptComponent scriptComponent)
     {
         var cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
@@ -71,7 +71,7 @@ public static class ScriptComponentExtensions
     /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
     /// <param name="cameraName">The name of the camera to retrieve.</param>
     /// <returns>The <see cref="CameraComponent"/> with the given name, if found; otherwise, null.</returns>
-    [Obsolete("Use GetGCCamera instead")]
+    [Obsolete("Use GetGCCamera instead or use Scene.GetCamera")]
     public static CameraComponent? GetCamera(this ScriptComponent scriptComponent, string cameraName)
     {
         var cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;
@@ -119,7 +119,7 @@ public static class ScriptComponentExtensions
     /// </remarks>
     /// <param name="scriptComponent">The script component from which to access the GraphicsCompositor.</param>
     /// <returns>The <see cref="CameraComponent"/> with the given name, if found; otherwise, null.</returns>
-    [Obsolete("Use GetFirstGCCamera instead")]
+    [Obsolete("Use GetFirstGCCamera instead or use Scene.GetCamera")]
     public static CameraComponent GetFirstCamera(this ScriptComponent scriptComponent)
     {
         SceneCameraSlotCollection cameraCollection = scriptComponent.SceneSystem.GraphicsCompositor.Cameras;


### PR DESCRIPTION
Added the following methods 
Entity.FindEntityRecursive() //to recursively search for an entity in the scene
Entity.GetComponentInChildren // recursively search through children to find a component
Scene.GetCamera() // returns the first camera in a scene
Scene.GetCamera(string) // returns the first camera in a scene with a given Entity name

Made the following extensions obsolete and added replacements.
ScriptComponent.GetCamera()
ScriptComponent.GetCamera(string)
ScriptComponent.GetFirstCamera()

replaced with:
GetGCCamera()
GetGCCamera(string)
GetFirstGCCamera

this should be a resolution to https://github.com/stride3d/stride-community-toolkit/issues/75