### PR TITLE
refactor!: Stride.Core.Assets.CompilerApp is removed from the toolkit

### DIFF
--- a/examples/code-only/Example01_Basic2DScene/Example01_Basic2DScene.csproj
+++ b/examples/code-only/Example01_Basic2DScene/Example01_Basic2DScene.csproj
@@ -7,9 +7,9 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <!--<ItemGroup>
-        <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2122" IncludeAssets="build" />
-    </ItemGroup>-->
+    <ItemGroup>
+        <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2122" IncludeAssets="build;buildTransitive" />
+    </ItemGroup>
 
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
         <Exec Command="copy ..\Resources\JumpyJetBackground.jpg $(OutDir)" />

--- a/examples/code-only/Example06_ImageProcessing/Example06_ImageProcessing.csproj
+++ b/examples/code-only/Example06_ImageProcessing/Example06_ImageProcessing.csproj
@@ -8,6 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2122" IncludeAssets="build;buildTransitive" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\..\src\Stride.CommunityToolkit\Stride.CommunityToolkit.csproj" />
     </ItemGroup>
 

--- a/src/Stride.CommunityToolkit/Stride.CommunityToolkit.csproj
+++ b/src/Stride.CommunityToolkit/Stride.CommunityToolkit.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <!-- The light requires a shader defined in the engine assemblies - but shaders are assets and I think they are compiled by the asset compiler per Graphics API target, that's why we need Stride.Core.Assets.CompilerApp -->
-        <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2122" IncludeAssets="build;buildTransitive" />
+        <!--<PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2067" IncludeAssets="build;buildTransitive" />-->
         <PackageReference Include="Stride.Engine" Version="4.2.0.2122" />
         <PackageReference Include="Stride.Particles" Version="4.2.0.2122" />
         <PackageReference Include="Stride.Physics" Version="4.2.0.2122" />


### PR DESCRIPTION
This should be added to individual projects