### PR TITLE
Attempt to fix missing shaders for debugshapes

### DIFF
--- a/src/Stride.CommunityToolkit/Stride.CommunityToolkit.sdpkg
+++ b/src/Stride.CommunityToolkit/Stride.CommunityToolkit.sdpkg
@@ -1,0 +1,16 @@
+!Package
+SerializedVersion: {Assets: 3.1.0.0}
+Meta:
+    Name: Stride.CommunityToolkit
+    Version: 1.0.0.0
+    Authors: []
+    Owners: []
+    Dependencies: null
+AssetFolders:
+    -   Path: !dir Rendering/DebugShapes/Effects
+ResourceFolders: []
+OutputGroupDirectories: {}
+ExplicitFolders: []
+Bundles: []
+TemplateFolders: []
+RootAssets: []


### PR DESCRIPTION
Im not really sure this will actually fix the problem described in https://github.com/stride3d/stride-community-toolkit/issues/132 but it is a common file between all other Stride packages.

