### PR TITLE
feat: Render Example code improvements

### DIFF
--- a/examples/code-only/Example09_Renderer/MyCustomSceneRenderer.cs
+++ b/examples/code-only/Example09_Renderer/MyCustomSceneRenderer.cs
@@ -1,0 +1,69 @@
+using Stride.CommunityToolkit.Engine;
+using Stride.Core.Mathematics;
+using Stride.Engine;
+using Stride.Graphics;
+using Stride.Rendering;
+using Stride.Rendering.Compositing;
+
+namespace Example09_Renderer;
+
+public class MyCustomSceneRenderer : SceneRendererBase
+{
+    private SpriteBatch? _spriteBatch;
+    private SpriteFont? _font;
+
+    // Font size for the text
+    private float _fontSize = 12;
+
+    private Scene? _scene;
+    private CameraComponent? _camera;
+    private Texture? _colorTexture;
+    private Vector2 _offset = new(0, -50);
+
+    protected override void InitializeCore()
+    {
+        base.InitializeCore();
+
+        _font = Content.Load<SpriteFont>("StrideDefaultFont");
+        _spriteBatch = new SpriteBatch(GraphicsDevice);
+        _colorTexture = Texture.New2D(GraphicsDevice, 1, 1, PixelFormat.R8G8B8A8_UNorm, new[] { Color.White });
+    }
+
+    protected override void DrawCore(RenderContext context, RenderDrawContext drawContext)
+    {
+        var graphicsCompositor = context.Tags.Get(GraphicsCompositor.Current);
+
+        if (graphicsCompositor is null) return;
+
+        _camera ??= graphicsCompositor.Cameras[0].Camera;
+
+        _scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
+
+        if (_spriteBatch is null || _camera is null || _scene is null) return;
+
+        _spriteBatch.Begin(drawContext.GraphicsContext);
+        _spriteBatch.DrawString(_font, "Hello Stride", 20, new Vector2(100, 100), Color.White);
+        _spriteBatch.End();
+
+        _spriteBatch.Begin(drawContext.GraphicsContext);
+
+        foreach (var entity in _scene.Entities)
+        {
+            var screen = _camera.WorldToScreenPoint(ref entity.Transform.Position, GraphicsDevice);
+
+            var text = $"{entity.Name}: {entity.Transform.Position:N1}";
+
+            var textDimensions = _spriteBatch.MeasureString(_font, text, _fontSize);
+
+            _spriteBatch.Draw(_colorTexture, new Rectangle(
+                (int)screen.X + (int)_offset.X,
+                (int)screen.Y + (int)_offset.Y,
+                (int)textDimensions.X,
+                (int)textDimensions.Y), new Color(200, 200, 200, 100));
+
+            _spriteBatch.DrawString(_font, text, _fontSize, screen + _offset, Color.Black);
+        }
+
+        _spriteBatch.End();
+    }
+}

--- a/examples/code-only/Example09_Renderer/MyCustomSceneRenderer.cs
+++ b/examples/code-only/Example09_Renderer/MyCustomSceneRenderer.cs
@@ -7,63 +7,110 @@ using Stride.Rendering.Compositing;
 
 namespace Example09_Renderer;
 
+/// <summary>
+/// A custom scene renderer that renders 2D text and a background for each entity in the scene.
+/// This class demonstrates how to use <see cref="SpriteBatch"/> for 2D rendering within a 3D scene.
+/// </summary>
+/// <remarks>
+/// This renderer uses <see cref="SceneRendererBase"/> to hook into the Stride rendering pipeline, rendering text above each entity
+/// with details like the entity's name and position. The renderer demonstrates both static and dynamic text rendering.
+/// </remarks>
 public class MyCustomSceneRenderer : SceneRendererBase
 {
+    // Instance of SpriteBatch used to render 2D elements like text
     private SpriteBatch? _spriteBatch;
+
+    // Font used for rendering text
     private SpriteFont? _font;
 
-    // Font size for the text
+    // Font size for the text rendered on the screen
     private float _fontSize = 12;
 
+    // The current scene being rendered
     private Scene? _scene;
+
+    // The camera used to convert world positions to screen positions
     private CameraComponent? _camera;
+
+    // A texture used to draw the background behind the text
     private Texture? _colorTexture;
+
+    // Offset for positioning the text relative to the entity's screen position
     private Vector2 _offset = new(0, -50);
 
+    /// <summary>
+    /// Initializes the renderer by loading necessary resources like fonts and creating a <see cref="SpriteBatch"/> for rendering 2D elements.
+    /// </summary>
     protected override void InitializeCore()
     {
         base.InitializeCore();
 
+        // Load the default font used for rendering text
         _font = Content.Load<SpriteFont>("StrideDefaultFont");
+
+        // Create a SpriteBatch instance for rendering 2D content
         _spriteBatch = new SpriteBatch(GraphicsDevice);
+
+        // Create a small texture (1x1 pixel) for drawing the background behind the text
         _colorTexture = Texture.New2D(GraphicsDevice, 1, 1, PixelFormat.R8G8B8A8_UNorm, new[] { Color.White });
     }
 
+    /// <summary>
+    /// Performs the actual drawing of the scene, including rendering text and backgrounds for each entity.
+    /// This method is called every frame.
+    /// </summary>
+    /// <param name="context">The rendering context that contains information about the current frame.</param>
+    /// <param name="drawContext">The draw context used for issuing draw commands to the graphics card.</param>
     protected override void DrawCore(RenderContext context, RenderDrawContext drawContext)
     {
+        // Get the active GraphicsCompositor (handles camera and rendering order)
         var graphicsCompositor = context.Tags.Get(GraphicsCompositor.Current);
 
         if (graphicsCompositor is null) return;
 
+        // Get the first camera in the graphics compositor (typically the main camera)
         _camera ??= graphicsCompositor.Cameras[0].Camera;
 
+        // Get the root scene for the current frame
         _scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
 
+        // Ensure all required components are initialized
         if (_spriteBatch is null || _camera is null || _scene is null) return;
 
+        // Begin the SpriteBatch for rendering static 2D text
         _spriteBatch.Begin(drawContext.GraphicsContext);
+
+        // Example of static text rendering (does not depend on entities)
         _spriteBatch.DrawString(_font, "Hello Stride", 20, new Vector2(100, 100), Color.White);
+
         _spriteBatch.End();
 
+        // Begin a new SpriteBatch for rendering dynamic entity information
         _spriteBatch.Begin(drawContext.GraphicsContext);
 
         foreach (var entity in _scene.Entities)
         {
+            // Convert the entity's world position to screen space
             var screen = _camera.WorldToScreenPoint(ref entity.Transform.Position, GraphicsDevice);
 
+            // Text to display the entity's name and position
             var text = $"{entity.Name}: {entity.Transform.Position:N1}";
 
+            // Measure the dimensions of the text to calculate background size
             var textDimensions = _spriteBatch.MeasureString(_font, text, _fontSize);
 
+            // Draw a semi-transparent background behind the text
             _spriteBatch.Draw(_colorTexture, new Rectangle(
                 (int)screen.X + (int)_offset.X,
                 (int)screen.Y + (int)_offset.Y,
                 (int)textDimensions.X,
                 (int)textDimensions.Y), new Color(200, 200, 200, 100));
 
+            // Draw the entity's name and position as text on the screen
             _spriteBatch.DrawString(_font, text, _fontSize, screen + _offset, Color.Black);
         }
 
+        // End the SpriteBatch
         _spriteBatch.End();
     }
 }

--- a/examples/code-only/Example09_Renderer/Program.cs
+++ b/examples/code-only/Example09_Renderer/Program.cs
@@ -1,16 +1,14 @@
+using Example09_Renderer;
 using Stride.CommunityToolkit.Engine;
 using Stride.CommunityToolkit.Rendering.Compositing;
 using Stride.CommunityToolkit.Rendering.ProceduralModels;
 using Stride.CommunityToolkit.Skyboxes;
 using Stride.Core.Mathematics;
 using Stride.Engine;
-using Stride.Graphics;
-using Stride.Rendering;
-using Stride.Rendering.Compositing;
 
 using var game = new Game();
 
-game.Run(start: (Scene rootScene) =>
+game.Run(start: (rootScene) =>
 {
     game.SetupBase3DScene();
     game.AddProfiler();
@@ -23,126 +21,7 @@ game.Run(start: (Scene rootScene) =>
 
     entity.Transform.Position = new Vector3(0, 8, 0);
 
+    entity.Add(new SpriteBatchRendererScript());
+
     entity.Scene = rootScene;
-
-    //entity.Add(new SpriteBatchRenderer());
 });
-
-public class MyCustomSceneRenderer : SceneRendererBase
-{
-    private SpriteBatch? _spriteBatch;
-    private SpriteFont? _font;
-    private Scene? _scene;
-    private CameraComponent? _camera;
-    private Texture? _colorTexture = null;
-    private Vector2 _offset = new(0, -50);
-
-    protected override void InitializeCore()
-    {
-        base.InitializeCore();
-
-        _font = Content.Load<SpriteFont>("StrideDefaultFont");
-        _spriteBatch = new SpriteBatch(GraphicsDevice);
-        _colorTexture = Texture.New2D(GraphicsDevice, 1, 1, PixelFormat.R8G8B8A8_UNorm, new[] { Color.White });
-    }
-
-    protected override void DrawCore(RenderContext context, RenderDrawContext drawContext)
-    {
-        var graphicsCompositor = context.Tags.Get(GraphicsCompositor.Current);
-
-        if (graphicsCompositor is null) return;
-
-        _camera ??= graphicsCompositor.Cameras[0].Camera;
-
-        _scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
-
-        if (_spriteBatch is null || _camera is null || _scene is null) return;
-
-        _spriteBatch.Begin(drawContext.GraphicsContext);
-        _spriteBatch.DrawString(_font, "Hello Stride", 20, new Vector2(100, 100), Color.White);
-        _spriteBatch.End();
-
-        _spriteBatch.Begin(drawContext.GraphicsContext);
-
-        foreach (var entity in _scene.Entities)
-        {
-            var screen = _camera.WorldToScreenPoint(ref entity.Transform.Position, GraphicsDevice);
-
-            var text = $"{entity.Name}: {entity.Transform.Position:N1}";
-            //var screen = entity.Transform.Position;
-
-            var dim = _spriteBatch.MeasureString(_font, text, 12);
-
-            _spriteBatch.Draw(_colorTexture, new Rectangle(
-                (int)screen.X + (int)_offset.X,
-                (int)screen.Y + (int)_offset.Y,
-                (int)dim.X,
-                (int)dim.Y), new Color(200, 200, 200, 100));
-
-            _spriteBatch.DrawString(_font, text, 12, screen + _offset, Color.Black);
-        }
-
-        _spriteBatch.End();
-    }
-}
-
-public class SpriteBatchRenderer : SyncScript
-{
-    private SpriteBatch? _spriteBatch;
-    private SpriteFont? _font;
-    private Texture? _texture;
-    private float _fontSize = 25;
-    private string _text = "This text is in Arial 20 with anti-alias\nand multiline...";
-    private DelegateSceneRenderer? _sceneRenderer;
-    private CameraComponent? _camera = null;
-
-    public override void Start()
-    {
-        _spriteBatch = new SpriteBatch(Game.GraphicsDevice);
-        _font = Content.Load<SpriteFont>("StrideDefaultFont");
-        //_ctx = new RenderDrawContext(Services, RenderContext.GetShared(Services), Game.GraphicsContext);
-        _sceneRenderer = new DelegateSceneRenderer(Draw);
-        _camera = SceneSystem.SceneInstance.RootScene.Entities.FirstOrDefault(x => x.Get<CameraComponent>() != null)?.Get<CameraComponent>();
-
-        var renderCollection = (SceneRendererCollection)SceneSystem.GraphicsCompositor.Game;
-
-        renderCollection.Add(_sceneRenderer);
-
-        //_texture = Content.Load<Texture>("Path to your texture asset");
-    }
-
-    public override void Update()
-    {
-        //_sceneRenderer.Draw(_ctx);
-
-        //var spriteBatch = new SpriteBatch(GraphicsDevice);
-
-        //// don't forget the begin
-        //spriteBatch.Begin(Game.GraphicsContext);
-
-        //// draw the text "Helloworld!" in red from the center of the screen
-        //spriteBatch.DrawString(_font, "Hello World!", new Vector2(200, 200), Color.Red);
-
-        //// don't forget the end
-        //spriteBatch.End();
-
-
-        //_spriteBatch.Begin(Game.GraphicsContext);
-
-        //_spriteBatch.DrawString(_font, _text, new Vector2(300, 300), Color.White);
-
-        //_spriteBatch.End();
-    }
-
-    private void Draw(RenderDrawContext drawContext)
-    {
-        var spriteBatch = new SpriteBatch(GraphicsDevice);
-
-        var screen = _camera.WorldToScreenPoint(ref Entity.Transform.Position, GraphicsDevice);
-
-        spriteBatch.Begin(drawContext.GraphicsContext);
-        spriteBatch.DrawString(_font, "Hello World 2", 20, screen + new Vector2(0, -50), Color.Red);
-        //spriteBatch.DrawString(_font, "Hello World 2", screen + new Vector2(0, -50), Color.Red, rotation: 0.5f, Vector2.Zero, Vector2.One, SpriteEffects.None, 0f, TextAlignment.Left);
-        spriteBatch.End();
-    }
-}

--- a/examples/code-only/Example09_Renderer/Program.cs
+++ b/examples/code-only/Example09_Renderer/Program.cs
@@ -15,7 +15,7 @@ game.Run(start: (Scene rootScene) =>
     game.SetupBase3DScene();
     game.AddProfiler();
 
-    game.AddSceneRenderer(new MyCustomRenderer(rootScene));
+    game.AddSceneRenderer(new MyCustomSceneRenderer());
 
     game.AddSkybox();
 
@@ -28,18 +28,14 @@ game.Run(start: (Scene rootScene) =>
     //entity.Add(new SpriteBatchRenderer());
 });
 
-public class MyCustomRenderer : SceneRendererBase
+public class MyCustomSceneRenderer : SceneRendererBase
 {
     private SpriteBatch? _spriteBatch;
     private SpriteFont? _font;
-    private Scene _scene;
+    private Scene? _scene;
     private CameraComponent? _camera;
     private Texture? _colorTexture = null;
-
-    public MyCustomRenderer(Scene scene)
-    {
-        //_scene = scene;
-    }
+    private Vector2 _offset = new(0, -50);
 
     protected override void InitializeCore()
     {
@@ -48,51 +44,25 @@ public class MyCustomRenderer : SceneRendererBase
         _font = Content.Load<SpriteFont>("StrideDefaultFont");
         _spriteBatch = new SpriteBatch(GraphicsDevice);
         _colorTexture = Texture.New2D(GraphicsDevice, 1, 1, PixelFormat.R8G8B8A8_UNorm, new[] { Color.White });
-        //_camera = _scene.Entities.FirstOrDefault(x => x.Get<CameraComponent>() != null)?.Get<CameraComponent>();
     }
 
     protected override void DrawCore(RenderContext context, RenderDrawContext drawContext)
     {
-        // Access to the graphics device
-        //var graphicsDevice = drawContext.GraphicsDevice;
-        //var commandList = drawContext.CommandList;
-        // Clears the current render target
-        //commandList.Clear(commandList.RenderTargets[0], Color.CornflowerBlue);
-
-        // get camera from context or drawContext
-
         var graphicsCompositor = context.Tags.Get(GraphicsCompositor.Current);
 
         if (graphicsCompositor is null) return;
 
         _camera ??= graphicsCompositor.Cameras[0].Camera;
 
-        //if (_camera is null)
-        //{
-        //    _camera = graphicsCompositor.Cameras[0].Camera;
-        //}
-
-        if (_scene is null)
-        {
-            _scene = context.Tags.Get(SceneInstance.Current).RootScene;
-        }
-
-        //_scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
+        _scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
 
         if (_spriteBatch is null || _camera is null || _scene is null) return;
 
         _spriteBatch.Begin(drawContext.GraphicsContext);
-        _spriteBatch.DrawString(_font, "Hello Stride 1.2", 20, new Vector2(100, 100), Color.White);
-        //_spriteBatch.Draw(_texture, Vector2.Zero);
+        _spriteBatch.DrawString(_font, "Hello Stride", 20, new Vector2(100, 100), Color.White);
         _spriteBatch.End();
 
-        // Get a refence to scene entities from context?
         _spriteBatch.Begin(drawContext.GraphicsContext);
-
-
-        const int x = 20;
-        const int y = 20;
-        var reposition = new Vector2(0, -50);
 
         foreach (var entity in _scene.Entities)
         {
@@ -104,13 +74,12 @@ public class MyCustomRenderer : SceneRendererBase
             var dim = _spriteBatch.MeasureString(_font, text, 12);
 
             _spriteBatch.Draw(_colorTexture, new Rectangle(
-                (int)screen.X + (int)reposition.X,
-                (int)screen.Y + (int)reposition.Y,
+                (int)screen.X + (int)_offset.X,
+                (int)screen.Y + (int)_offset.Y,
                 (int)dim.X,
                 (int)dim.Y), new Color(200, 200, 200, 100));
 
-            _spriteBatch.DrawString(_font, text, 12, screen + reposition, Color.Black);
-            //spriteBatch.DrawString(_font, "Hello World 2", screen + new Vector2(0, -50), Color.Red, rotation: 0.5f, Vector2.Zero, Vector2.One, SpriteEffects.None, 0f, TextAlignment.Left);
+            _spriteBatch.DrawString(_font, text, 12, screen + _offset, Color.Black);
         }
 
         _spriteBatch.End();
@@ -126,7 +95,6 @@ public class SpriteBatchRenderer : SyncScript
     private string _text = "This text is in Arial 20 with anti-alias\nand multiline...";
     private DelegateSceneRenderer? _sceneRenderer;
     private CameraComponent? _camera = null;
-
 
     public override void Start()
     {

--- a/examples/code-only/Example09_Renderer/Program.cs
+++ b/examples/code-only/Example09_Renderer/Program.cs
@@ -6,22 +6,40 @@ using Stride.CommunityToolkit.Skyboxes;
 using Stride.Core.Mathematics;
 using Stride.Engine;
 
+// This example demonstrates two different ways of adding custom rendering logic to a Stride game.
+// 1. Using a custom SceneRenderer via MyCustomSceneRenderer, which renders text for all entities.
+// 2. Using a StartupScript via SpriteBatchRendererScript, which draws specific text for a single entity.
+// Both approaches integrate into the Stride rendering pipeline, demonstrating how to extend the default rendering behaviour.
+
 using var game = new Game();
 
-game.Run(start: (rootScene) =>
+/// <summary>
+/// Entry point for the game setup. The game runs with two main customizations:
+/// 1. A custom scene renderer is added to display entity debug information using SpriteBatch.
+/// 2. A custom script is added to an entity for specific entity-related rendering (e.g., "Hello Stride").
+/// </summary>
+game.Run(start: (scene) =>
 {
+    // Sets up the base 3D scene, including lighting, camera, and default settings.
     game.SetupBase3DScene();
+
+    // Adds the built-in profiler, which provides real-time performance metrics.
     game.AddProfiler();
 
+    // Example 1: Adds a custom scene renderer to render text for all entities in the scene.
     game.AddSceneRenderer(new MyCustomSceneRenderer());
 
+    // Adds a skybox (a background environment) to the scene.
     game.AddSkybox();
 
+    // Creates a 3D capsule primitive and sets its position in the scene.
     var entity = game.Create3DPrimitive(PrimitiveModelType.Capsule);
-
     entity.Transform.Position = new Vector3(0, 8, 0);
 
+    // Example 2: Adds a custom startup script to the entity, which draws specific text
+    // (e.g., "Hello Stride 2") using SpriteBatch when the game is running.
     entity.Add(new SpriteBatchRendererScript());
 
-    entity.Scene = rootScene;
+    // Assigns the entity to the root scene to ensure it is rendered and updated.
+    entity.Scene = scene;
 });

--- a/examples/code-only/Example09_Renderer/SpriteBatchRendererScript.cs
+++ b/examples/code-only/Example09_Renderer/SpriteBatchRendererScript.cs
@@ -1,0 +1,80 @@
+using Stride.CommunityToolkit.Engine;
+using Stride.CommunityToolkit.Rendering.Compositing;
+using Stride.Core.Mathematics;
+using Stride.Engine;
+using Stride.Graphics;
+using Stride.Rendering;
+using Stride.Rendering.Compositing;
+
+namespace Example09_Renderer;
+
+/// <summary>
+/// A startup script that demonstrates adding a custom scene renderer to the Stride engine's rendering pipeline.
+/// This script uses <see cref="SpriteBatch"/> to render 2D text on the screen.
+/// </summary>
+/// <remarks>
+/// This example showcases how to create a custom renderer and add it through the <see cref="StartupScript"/> mechanism.
+/// It demonstrates rendering 2D text based on the world position of an entity, converting it to screen space using the camera's view.
+/// </remarks>
+public class SpriteBatchRendererScript : StartupScript
+{
+    // Instance of SpriteBatch used to render 2D elements
+    private SpriteBatch? _spriteBatch;
+
+    // Font used for rendering text
+    private SpriteFont? _font;
+
+    // Font size for the text
+    private float _fontSize = 18;
+
+    // Reference to the camera component used for world-to-screen transformation
+    private CameraComponent? _camera;
+
+    // Offset to position the text relative to the world position
+    private Vector2 _offset = new(0, -80);
+
+    /// <summary>
+    /// Initializes the scene renderer by creating a <see cref="DelegateSceneRenderer"/> that renders custom 2D text using <see cref="SpriteBatch"/>.
+    /// This method is called when the script starts.
+    /// </summary>
+    public override void Start()
+    {
+        // Initialize the SpriteBatch for drawing 2D content
+        _spriteBatch = new SpriteBatch(Game.GraphicsDevice);
+
+        // Load the default font used for rendering text
+        _font = Content.Load<SpriteFont>("StrideDefaultFont");
+
+        // Get the camera from the root scene to calculate world-to-screen coordinates
+        _camera = SceneSystem.SceneInstance.RootScene.GetCamera();
+
+        // Create a custom scene renderer using a delegate for the Draw method
+        var sceneRenderer = new DelegateSceneRenderer(Draw);
+
+        // Add the custom scene renderer to the graphics compositor, which will manage its rendering
+        SceneSystem.GraphicsCompositor.AddSceneRenderer(sceneRenderer);
+    }
+
+    /// <summary>
+    /// Custom draw method that renders 2D text on the screen using the world position of the entity.
+    /// This method is called during the rendering phase.
+    /// </summary>
+    /// <param name="drawContext">The rendering context used to issue draw commands.</param>
+    private void Draw(RenderDrawContext drawContext)
+    {
+        // Ensure the necessary components (SpriteBatch, font, and camera) are initialized
+        if (_spriteBatch == null || _font == null || _camera == null) return;
+
+        // Convert the world position of the entity to screen space coordinates
+        var screen = _camera.WorldToScreenPoint(ref Entity.Transform.Position, GraphicsDevice);
+
+        // Begin the 2D rendering process using SpriteBatch
+        _spriteBatch.Begin(drawContext.GraphicsContext);
+
+        // Draw a red "Hello Stride 2" text at the specified screen position, applying the offset
+        _spriteBatch.DrawString(_font, "Hello Stride 2", _fontSize, screen + _offset, Color.Red);
+
+        // End the SpriteBatch rendering process
+        _spriteBatch.End();
+    }
+}

--- a/src/Stride.CommunityToolkit/Engine/GameExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/GameExtensions.cs
@@ -25,6 +25,8 @@ namespace Stride.CommunityToolkit.Engine;
 public static class GameExtensions
 {
     private const string DefaultGroundName = "Ground";
+    private const string GraphicsCompositorNotSet = "GraphicsCompositor is not set.";
+
     private static readonly Vector2 _default3DGroundSize = new(15f);
     private static readonly Vector3 _default2DGroundSize = new(15, 0.1f, 0);
     private static readonly Color _defaultMaterialColor = Color.FromBgra(0xFF8C8C8C);
@@ -741,7 +743,7 @@ public static class GameExtensions
     {
         ArgumentNullException.ThrowIfNull(renderer);
 
-        var graphicsCompositor = game.SceneSystem.GraphicsCompositor ?? throw new InvalidOperationException("GraphicsCompositor is not set.");
+        var graphicsCompositor = game.SceneSystem.GraphicsCompositor ?? throw new InvalidOperationException(GraphicsCompositorNotSet);
 
         graphicsCompositor.AddSceneRenderer(renderer);
     }
@@ -788,7 +790,7 @@ public static class GameExtensions
     /// </example>
     public static void AddEntityDebugSceneRenderer(this Game game, EntityDebugSceneRendererOptions? options = null)
     {
-        var graphicsCompositor = game.SceneSystem.GraphicsCompositor ?? throw new InvalidOperationException("GraphicsCompositor is not set.");
+        var graphicsCompositor = game.SceneSystem.GraphicsCompositor ?? throw new InvalidOperationException(GraphicsCompositorNotSet);
 
         graphicsCompositor.AddEntityDebugRenderer(options);
     }

--- a/src/Stride.CommunityToolkit/Rendering/Compositing/EntityDebugSceneRenderer.cs
+++ b/src/Stride.CommunityToolkit/Rendering/Compositing/EntityDebugSceneRenderer.cs
@@ -57,19 +57,9 @@ public class EntityDebugSceneRenderer : SceneRendererBase
 
         if (graphicsCompositor is null) return;
 
-        if (_camera is null)
-        {
-            _camera = graphicsCompositor.Cameras[0].Camera;
-        }
+        _camera ??= graphicsCompositor.Cameras[0].Camera;
 
-        //_camera ??= graphicsCompositor.Cameras[0].Camera;
-
-        if (_scene is null)
-        {
-            _scene = context.Tags.Get(SceneInstance.Current).RootScene;
-        }
-
-        //_scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
+        _scene ??= context.Tags.Get(SceneInstance.Current).RootScene;
 
         if (_spriteBatch is null || _camera is null || _scene is null) return;
 


### PR DESCRIPTION
This pull request introduces a custom scene renderer and a startup script for rendering 2D text in a 3D scene using the Stride engine. It also includes some refactoring and cleanup of existing code. The most important changes include the creation of `MyCustomSceneRenderer`, the addition of `SpriteBatchRendererScript`, and refactoring in the `GameExtensions` class.

### New Features:

* [`examples/code-only/Example09_Renderer/MyCustomSceneRenderer.cs`](diffhunk://#diff-8c41a2bbdebd2d99e41f29f1945f208ea1c38c62c483653252dea1da73a6a462R1-R116): Added a custom scene renderer class `MyCustomSceneRenderer` that renders 2D text and a background for each entity in the scene using `SpriteBatch`.
* [`examples/code-only/Example09_Renderer/SpriteBatchRendererScript.cs`](diffhunk://#diff-c92bc80720e940519c46fbdc1139f144f574406706c13231a4ea79fac1e72171R1-R80): Introduced `SpriteBatchRendererScript`, a startup script that demonstrates adding a custom scene renderer to the Stride engine's rendering pipeline.

### Refactoring:

* [`examples/code-only/Example09_Renderer/Program.cs`](diffhunk://#diff-ee02e6472fbc2e417606c0d14664c6bd3b54f48becc72fdbc992ffd8f453c119R1-L180): Updated the game setup to include the new custom scene renderer and startup script, and removed the old `MyCustomRenderer` class.
* [`src/Stride.CommunityToolkit/Engine/GameExtensions.cs`](diffhunk://#diff-4d9af20f82db0f707938f15af77e887d5f033c751d3d572f9e0e94782680efdbR28-R29): Refactored error messages by introducing a constant `GraphicsCompositorNotSet` for consistency. [[1]](diffhunk://#diff-4d9af20f82db0f707938f15af77e887d5f033c751d3d572f9e0e94782680efdbR28-R29) [[2]](diffhunk://#diff-4d9af20f82db0f707938f15af77e887d5f033c751d3d572f9e0e94782680efdbL744-R746) [[3]](diffhunk://#diff-4d9af20f82db0f707938f15af77e887d5f033c751d3d572f9e0e94782680efdbL791-R793)

### Code Cleanup:

* [`src/Stride.CommunityToolkit/Rendering/Compositing/EntityDebugSceneRenderer.cs`](diffhunk://#diff-f52fc96abf4a105a3b18d8c7be41701a35d424a117a2dfc023cf4b4fdac97d25L60-R62): Simplified the initialization of `_camera` and `_scene` in `DrawCore` method.