### PR TITLE
fix: Fixed Skybox environemnt light generation

### DIFF
--- a/src/Stride.CommunityToolkit.Skyboxes/GameExtensions.cs
+++ b/src/Stride.CommunityToolkit.Skyboxes/GameExtensions.cs
@@ -35,7 +35,7 @@ public static class GameExtensions
     /// </example>
     public static Entity AddSkybox(this Game game, string? entityName = "Skybox")
     {
-        using var stream = new FileStream($"{AppContext.BaseDirectory}Resources\\{SkyboxTexture}", FileMode.Open, FileAccess.Read);
+        using var stream = new FileStream(Path.Combine(AppContext.BaseDirectory, "Resources", SkyboxTexture), FileMode.Open, FileAccess.Read);
 
         var texture = Texture.Load(game.GraphicsDevice, stream, TextureFlags.ShaderResource, GraphicsResourceUsage.Dynamic);
 

--- a/src/Stride.CommunityToolkit.Skyboxes/SkyboxGenerator.cs
+++ b/src/Stride.CommunityToolkit.Skyboxes/SkyboxGenerator.cs
@@ -36,9 +36,12 @@ public static class SkyboxGenerator
     {
         var cubemapSize = (int)Math.Pow(2, Math.Ceiling(Math.Log(skyboxTexture.Width / 4) / Math.Log(2))); // maximum resolution is around horizontal middle line which composes 4 images.
 
-        skyboxTexture = CubemapFromTextureRenderer.GenerateCubemap(context.Services, context.RenderDrawContext, skyboxTexture, cubemapSize);
+        if (skyboxTexture.Dimension != TextureDimension.TextureCube)
+        {
+            skyboxTexture = CubemapFromTextureRenderer.GenerateCubemap(context.Services, context.RenderDrawContext, skyboxTexture, cubemapSize);
+        }
 
-        var lamberFiltering = new LambertianPrefilteringSHNoCompute(context.RenderContext)
+        using var lamberFiltering = new LambertianPrefilteringSHNoCompute(context.RenderContext)
         {
             HarmonicOrder = 3,
             RadianceMap = skyboxTexture
@@ -52,7 +55,7 @@ public static class SkyboxGenerator
         skybox.DiffuseLightingParameters.Set(SkyboxKeys.Shader, new ShaderClassSource("SphericalHarmonicsEnvironmentColor", lamberFiltering.HarmonicOrder));
         skybox.DiffuseLightingParameters.Set(SphericalHarmonicsEnvironmentColorKeys.SphericalColors, coefficients);
 
-        var specularRadiancePrefilterGGX = new RadiancePrefilteringGGXNoCompute(context.RenderContext);
+        using var specularRadiancePrefilterGGX = new RadiancePrefilteringGGXNoCompute(context.RenderContext);
 
         //var textureSize = asset.SpecularCubeMapSize <= 0 ? 64 : asset.SpecularCubeMapSize;
         // Not sure what should be here


### PR DESCRIPTION
GenerateCubemap did not work for some reason, but I kept it and made it conditonal in case a non cube map is submitted, no idea if it will work in that case though. I also fixed the path generation so that it should work on non windows systems and made sure resources are disposed.