### PR TITLE
fix: Include .sdpkg files in package output

### DIFF
--- a/src/Stride.CommunityToolkit/Stride.CommunityToolkit.csproj
+++ b/src/Stride.CommunityToolkit/Stride.CommunityToolkit.csproj
@@ -21,6 +21,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Include="*.sdpkg" Pack="true" PackagePath="stride" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Compile Update="Engine\EntityExtensions.GetComponents.cs">
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>


### PR DESCRIPTION
- Added a new `ItemGroup` to `Stride.CommunityToolkit.csproj` with the `<None Include="*.sdpkg" Pack="true" PackagePath="stride" />` element.