### PR TITLE
docs: Update troubleshooting guide

### DIFF
--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -3,14 +3,14 @@
 ## Building Project Issues
 
 1. **Error - Could not load native library libcore using CPU architecture x64**
-   - Missing Microsoft Visual C++ Redistributable
+   - Missing Microsoft Visual C++ Redistributable, make sure you install [prerequisites](getting-started.md)
        ```
         C:\Users\Vacla\.nuget\packages\stride.core.assets.compilerapp\4.1.0.1728\buildTransitive\Stride.Core.Assets.CompilerApp.targets(132,5): error MSB3073: The command ""C:\Users\Vacla\.nuget\packages\stride.core.assets.compilerapp\4.1.0.1728\buildTransitive\..\tools\net6.0-windows7.0\Stride.Core.Assets.CompilerApp.exe"  --disable-auto- 
         compile --project-configuration "Debug" --platform=Windows --project-configuration=Debug --compile-property:StrideGraphicsApi=Direct3D11 --output-path="C:\Projects\StrideDemo\bin\Debug\net6.0\data" --build-path="C:\Projects\StrideDemo\obj\stride\assetbuild\data" --package-file="C:\Projects\StrideDemo\StrideDemo.csproj" --msbuild-up 
         todatecheck-filebase="C:\Projects\StrideDemo\obj\Debug\net6.0\stride\assetcompiler-uptodatecheck"" exited with code -532462766. [C:\Projects\StrideDemo\StrideDemo.csproj]
        ```
 1. **Error - Unable to instantiate compiler**
-   - Missing Microsoft Visual C++ Redistributable
+   - Missing Microsoft Visual C++ Redistributable, make sure you install [prerequisites](getting-started.md)
         ```
         EXEC : error 6.206s: [AssetsCompiler.AttributeBasedRegistry] Unable to instantiate compiler [Stride.A
         ssets.Physics.ColliderShapeAsset, Stride.Assets, Version=4.1.0.1898, Culture=neutral, PublicKeyToken=
@@ -47,3 +47,32 @@
         d-uptodatecheck-filebase="D:\Projects\GitHub\Stride Projects\Console01\obj\Debug\net8.0\stride\assetcompiler-uptodatech
         eck" exited with code 1. [D:\Projects\GitHub\Stride Projects\Console01\Console01.csproj]
         ```
+1. **Error - at Stride.Shaders.Compiler.TaskOrResult.**
+   - If this is from code-only, make sure you added `Stride.CommunityToolkit.Windows` NuGet package instead of `Stride.CommunityToolkit`, further instructions can be found [here](code-only/create-project.md)
+    ```
+     at Stride.Shaders.Compiler.TaskOrResult`1.WaitForResult() in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Shaders\Compiler\TaskOrResult.cs:line 37
+       at Stride.Rendering.DynamicEffectInstance.ChooseEffect(GraphicsDevice graphicsDevice) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Rendering\Rendering\DynamicEffectInstance.cs:line 60
+       at Stride.Rendering.EffectInstance.UpdateEffect(GraphicsDevice graphicsDevice)
+       at Stride.Rendering.Images.ImageEffectShader.DrawCore(RenderDrawContext context) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Rendering\Rendering\Images\ImageEffectShader.cs:line 147
+       at Stride.Rendering.RendererBase.Draw(RenderDrawContext context) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Rendering\Rendering\RendererBase.cs:line 51
+       at Stride.Rendering.ComputeEffect.LambertianPrefiltering.LambertianPrefilteringSHNoCompute.DrawCore(RenderDrawContext context) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Rendering\Rendering\ComputeEffect\LambertianPrefiltering\LambertianPrefilteringSHNoCompute.cs:line 99
+       at Stride.Rendering.RendererBase.Draw(RenderDrawContext context) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Rendering\Rendering\RendererBase.cs:line 51
+       at Stride.CommunityToolkit.Skyboxes.SkyboxGenerator.Generate(Skybox skybox, SkyboxGeneratorContext context, Texture skyboxTexture) in D:\a\stride-community-toolkit\stride-community-toolkit\src\Stride.CommunityToolkit.Skyboxes\SkyboxGenerator.cs:line 49
+       at Stride.CommunityToolkit.Skyboxes.GameExtensions.AddSkybox(Game game, String entityName) in D:\a\stride-community-toolkit\stride-community-toolkit\src\Stride.CommunityToolkit.Skyboxes\GameExtensions.cs:line 46
+       at Program.<>c__DisplayClass0_0.<<Main>$>b__0(Scene rootScene) in C:\Users\user-name\RiderProjects\Label3d\Program.cs:line 13
+       at Stride.CommunityToolkit.Engine.GameExtensions.<>c__DisplayClass0_0.<<Run>g__RootScript|0>d.MoveNext() in D:\a\stride-community-toolkit\stride-community-toolkit\src\Stride.CommunityToolkit\Engine\GameExtensions.cs:line 46  
+    --- End of stack trace from previous location ---
+       at Stride.Core.MicroThreading.MicroThread.<>c__DisplayClass52_0.<<Start>b__0>d.MoveNext() in C:\BuildAgent\work\b5f46e3c4829a09e\sources\core\Stride.Core.MicroThreading\MicroThread.cs:line 176
+    --- End of stack trace from previous location ---
+       at Stride.Core.MicroThreading.Scheduler.Run() in C:\BuildAgent\work\b5f46e3c4829a09e\sources\core\Stride.Core.MicroThreading\Scheduler.cs:line 203
+       at Stride.Engine.Processors.ScriptSystem.Update(GameTime gameTime) in C:\BuildAgent\work\b5f46e3c4829a09e\sources\engine\Stride.Engine\Engine\Processors\ScriptSystem.cs:line 106
+       at Stride.Games.GameSystemCollection.Update(GameTime gameTime)
+       at Stride.Games.GameBase.Update(GameTime gameTime)
+       at Stride.Games.GameBase.InitializeBeforeRun()
+       at Stride.Games.GamePlatform.OnInitCallback()
+       at Stride.Games.GameWindowSDL.Run()
+       at Stride.Games.GamePlatform.Run(GameContext gameContext)
+       at Stride.Games.GameBase.Run(GameContext gameContext)
+       at Stride.CommunityToolkit.Engine.GameExtensions.Run(Game game, GameContext context, Action`1 start, Action`2 update) in D:\a\stride-community-toolkit\stride-community-toolkit\src\Stride.CommunityToolkit\Engine\GameExtensions.cs:line 42
+       at Program.<Main>$(String[] args) in C:\Users\user-name\RiderProjects\Label3d\Program.cs:line 101. 
+    ```

--- a/docs/run.bat
+++ b/docs/run.bat
@@ -10,4 +10,4 @@ del /Q "api\.manifest"
 
 REM --maxParallelism 1
 
-docfx docfx.json --serve --maxParallelism 1
+docfx docfx.json --maxParallelism 1 --serve


### PR DESCRIPTION
docs: Update troubleshooting guide

- Enhanced `troubleshooting.md` with additional guidance for resolving specific errors:
  - For "Could not load native library libcore using CPU architecture x64," added a suggestion to ensure the installation of prerequisites by referring to the [prerequisites](getting-started.md) link.
  - For "Unable to instantiate compiler," advised checking the prerequisites.
  - Added a new error section "Error - at Stride.Shaders.Compiler.TaskOrResult" with a detailed stack trace and a suggestion to add the `Stride.CommunityToolkit.Windows` NuGet package for code-only projects, with further instructions via a link to the relevant documentation.